### PR TITLE
Correct filename case in #include directives

### DIFF
--- a/excluded/experimental/MacroGatedLPF.cpp
+++ b/excluded/experimental/MacroGatedLPF.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "MacroGatedLPF.h"
-#include "defines.h"
+#include "Defines.h"
 
 // Include the modules
 #include "ModuleLowpassFilter.h"

--- a/excluded/experimental/ModuleADSR.cpp.older
+++ b/excluded/experimental/ModuleADSR.cpp.older
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleADSR.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleADSR::ModuleADSR()
 {

--- a/excluded/experimental/ModuleAudioEFX.cpp
+++ b/excluded/experimental/ModuleAudioEFX.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleAudioEFX.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleAudioEFX::ModuleAudioEFX(Equations *equations)
 {

--- a/excluded/experimental/ModuleCAOsc.cpp
+++ b/excluded/experimental/ModuleCAOsc.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleCAOsc.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleCAOsc::ModuleCAOsc()
 {

--- a/excluded/experimental/ModuleChatBot.cpp
+++ b/excluded/experimental/ModuleChatBot.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleChatBot.h"
-#include "defines.h"
+#include "Defines.h"
 
 /*
 

--- a/excluded/experimental/ModuleChords.cpp
+++ b/excluded/experimental/ModuleChords.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleChords.h"
-#include "defines.h"
+#include "Defines.h"
 #include "Scales.h"
 
 ModuleChords::ModuleChords()

--- a/excluded/experimental/ModuleDrum.cpp
+++ b/excluded/experimental/ModuleDrum.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleDrum.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleDrum::ModuleDrum()
 {

--- a/excluded/experimental/ModuleEqWaveOsc.cpp
+++ b/excluded/experimental/ModuleEqWaveOsc.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleEqWaveOsc.h"
-#include "defines.h"
+#include "Defines.h"
 
 // #define WAVETABLE_LENGTH 512
 

--- a/excluded/experimental/ModuleEquationShot.cpp
+++ b/excluded/experimental/ModuleEquationShot.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleEquationShot.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleEquationShot::ModuleEquationShot(Equations *equations)
 {

--- a/excluded/experimental/ModuleHighpassFilter.cpp
+++ b/excluded/experimental/ModuleHighpassFilter.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleHighpassFilter.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleHighpassFilter::ModuleHighpassFilter()
 {

--- a/excluded/experimental/ModuleLowpassFilter.cpp
+++ b/excluded/experimental/ModuleLowpassFilter.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleLowpassFilter.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleLowpassFilter::ModuleLowpassFilter()
 {

--- a/excluded/experimental/ModuleReverb.cpp
+++ b/excluded/experimental/ModuleReverb.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleReverb.h"
-#include "defines.h"
+#include "Defines.h"
 #include "GlobalRingBuffer.h"
 
 ModuleReverb::ModuleReverb()

--- a/excluded/experimental/ModuleRingMod.cpp
+++ b/excluded/experimental/ModuleRingMod.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleRingMod.h"
-#include "defines.h"
+#include "Defines.h"
 #include "GlobalWavetables.h"
 #include "GlobalIncrements.h"
 

--- a/excluded/experimental/ModuleSoundToy.cpp
+++ b/excluded/experimental/ModuleSoundToy.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleSoundToy.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleSoundToy::ModuleSoundToy()
 {

--- a/excluded/experimental/ModuleSpeechSound.cpp
+++ b/excluded/experimental/ModuleSpeechSound.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleSpeechSound.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleSpeechSound::ModuleSpeechSound()
 {

--- a/excluded/experimental/ModuleVocalizer.cpp
+++ b/excluded/experimental/ModuleVocalizer.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleVocalizer.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleVocalizer::ModuleVocalizer()
 {

--- a/excluded/experimental/ModuleWalkSequencer.cpp
+++ b/excluded/experimental/ModuleWalkSequencer.cpp
@@ -1,7 +1,7 @@
 /*
 #include "Arduino.h"
 #include "ModuleWalkSequencer.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleWalkSequencer::ModuleWalkSequencer()
 {

--- a/excluded/experimental/ModuleWaveshaper.cpp
+++ b/excluded/experimental/ModuleWaveshaper.cpp
@@ -1,5 +1,5 @@
 
-#include "defines.h"
+#include "Defines.h"
 #include "ModuleWaveshaper.h"
 
 ModuleWaveshaper::ModuleWaveshaper()

--- a/excluded/experimental/ModuleWavetable.cpp
+++ b/excluded/experimental/ModuleWavetable.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleWavetable.h"
-#include "defines.h"
+#include "Defines.h"
 
 #define WAVETABLE_LENGTH 512
 

--- a/excluded/experimental/ModuleWords.cpp
+++ b/excluded/experimental/ModuleWords.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleWords.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleWords::ModuleWords()
 {

--- a/excluded/experimental/SynthChatterbox.cpp
+++ b/excluded/experimental/SynthChatterbox.cpp
@@ -1,5 +1,5 @@
 #include "Arduino.h"
-#include "defines.h"
+#include "Defines.h"
 #include "SynthChatterbox.h"
 
 SynthChatterbox::SynthChatterbox(Module* inputs[])

--- a/excluded/experimental/SynthDCOffsetTest.cpp
+++ b/excluded/experimental/SynthDCOffsetTest.cpp
@@ -1,5 +1,5 @@
 #include "Arduino.h"
-#include "defines.h"
+#include "Defines.h"
 #include "SynthDCOffsetTest.h"
 
 SynthDCOffsetTest::SynthDCOffsetTest(Module* inputs[])

--- a/excluded/main_module/EquationComposer.ino
+++ b/excluded/main_module/EquationComposer.ino
@@ -46,7 +46,7 @@ TODO:
 
 
 
-#include "defines.h"
+#include "Defines.h"
 
 // Setting the debug flag to 1 turns off the timer functions.  This causes the
 // code to run slowly, and at that slow frequency the module is inaudible.  

--- a/excluded/main_module/ModuleAdd.cpp
+++ b/excluded/main_module/ModuleAdd.cpp
@@ -1,5 +1,5 @@
 #include "ModuleAdd.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleAdd::ModuleAdd()
 {

--- a/excluded/main_module/ModuleArpeggio.cpp
+++ b/excluded/main_module/ModuleArpeggio.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleArpeggio.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleArpeggio::ModuleArpeggio()
 {

--- a/excluded/main_module/ModuleChords.cpp
+++ b/excluded/main_module/ModuleChords.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleChords.h"
-#include "defines.h"
+#include "Defines.h"
 #include "GlobalScales.h"
 #include "GlobalChords.h"
 

--- a/excluded/main_module/ModuleClockedRandom.cpp
+++ b/excluded/main_module/ModuleClockedRandom.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleClockedRandom.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleClockedRandom::ModuleClockedRandom()
 {

--- a/excluded/main_module/ModuleCounter.cpp
+++ b/excluded/main_module/ModuleCounter.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleCounter.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleCounter::ModuleCounter(int target)
 {

--- a/excluded/main_module/ModuleDrumSequencer.cpp
+++ b/excluded/main_module/ModuleDrumSequencer.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleDrumSequencer.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleDrumSequencer::ModuleDrumSequencer()
 {

--- a/excluded/main_module/ModuleDrumSequencer32.cpp
+++ b/excluded/main_module/ModuleDrumSequencer32.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleDrumSequencer32.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleDrumSequencer32::ModuleDrumSequencer32()
 {

--- a/excluded/main_module/ModuleENV.cpp
+++ b/excluded/main_module/ModuleENV.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleENV.h"
-#include "defines.h"
+#include "Defines.h"
 #include "GlobalSlopes.h"
 
 ModuleENV::ModuleENV()

--- a/excluded/main_module/ModuleEqDrum.cpp
+++ b/excluded/main_module/ModuleEqDrum.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleEqDrum.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleEqDrum::ModuleEqDrum()
 {

--- a/excluded/main_module/ModuleEquationLooper.cpp
+++ b/excluded/main_module/ModuleEquationLooper.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleEquationLooper.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleEquationLooper::ModuleEquationLooper(EquationBank *equation_bank)
 {

--- a/excluded/main_module/ModuleExtClock.cpp
+++ b/excluded/main_module/ModuleExtClock.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleExtClock.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleExtClock::ModuleExtClock(uint8_t bpm, uint16_t clock_division)
 {

--- a/excluded/main_module/ModuleMap.cpp
+++ b/excluded/main_module/ModuleMap.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleMap.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleMap::ModuleMap(uint32_t low, uint32_t high)
 {

--- a/excluded/main_module/ModuleMultiply.cpp
+++ b/excluded/main_module/ModuleMultiply.cpp
@@ -1,5 +1,5 @@
 #include "ModuleMultiply.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleMultiply::ModuleMultiply()
 {

--- a/excluded/main_module/ModuleOscParam.cpp
+++ b/excluded/main_module/ModuleOscParam.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleOscParam.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleOscParam::ModuleOscParam()
 {

--- a/excluded/main_module/ModulePatternGenerator.cpp
+++ b/excluded/main_module/ModulePatternGenerator.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModulePatternGenerator.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModulePatternGenerator::ModulePatternGenerator()
 {

--- a/excluded/main_module/ModuleQuantizer.cpp
+++ b/excluded/main_module/ModuleQuantizer.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleQuantizer.h"
-#include "defines.h"
+#include "Defines.h"
 #include "GlobalScales.h"
 
 uint16_t ModuleQuantizer::compute()

--- a/excluded/main_module/ModuleRotatingRouter3.cpp
+++ b/excluded/main_module/ModuleRotatingRouter3.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleRotatingRouter3.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleRotatingRouter3::ModuleRotatingRouter3()
 {

--- a/excluded/main_module/ModuleSampleAndHold.cpp
+++ b/excluded/main_module/ModuleSampleAndHold.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleSampleAndHold.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleSampleAndHold::ModuleSampleAndHold()
 {

--- a/excluded/main_module/ModuleSequencer.cpp
+++ b/excluded/main_module/ModuleSequencer.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleSequencer.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleSequencer::ModuleSequencer(int values[])
 {

--- a/excluded/main_module/ModuleSmooth.cpp
+++ b/excluded/main_module/ModuleSmooth.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleSmooth.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleSmooth::ModuleSmooth()
 {

--- a/excluded/main_module/ModuleWaveFolder.cpp
+++ b/excluded/main_module/ModuleWaveFolder.cpp
@@ -1,5 +1,5 @@
 #include "ModuleWaveFolder.h"
-#include "defines.h"
+#include "Defines.h"
 
 ModuleWaveFolder::ModuleWaveFolder()
 {

--- a/excluded/main_module/SynthArpeggio1.cpp
+++ b/excluded/main_module/SynthArpeggio1.cpp
@@ -1,5 +1,5 @@
 #include "Arduino.h"
-#include "defines.h"
+#include "Defines.h"
 #include "SynthArpeggio1.h"
 
 SynthArpeggio1::SynthArpeggio1(Inputs* inputs)

--- a/excluded/main_module/SynthAutoDrum.cpp
+++ b/excluded/main_module/SynthAutoDrum.cpp
@@ -1,4 +1,4 @@
-#include "defines.h"
+#include "Defines.h"
 #include "SynthAutoDrum.h"
 
 SynthAutoDrum::SynthAutoDrum(Inputs* inputs)

--- a/excluded/main_module/SynthDrumPlayer.cpp
+++ b/excluded/main_module/SynthDrumPlayer.cpp
@@ -1,4 +1,4 @@
-#include "defines.h"
+#include "Defines.h"
 #include "SynthDrumPlayer.h"
 
 SynthDrumPlayer::SynthDrumPlayer(Inputs* inputs)

--- a/excluded/main_module/SynthLooper.cpp
+++ b/excluded/main_module/SynthLooper.cpp
@@ -1,4 +1,4 @@
-#include "defines.h"
+#include "Defines.h"
 #include "SynthLooper.h"
 
 SynthLooper::SynthLooper(Inputs* inputs)

--- a/excluded/main_module/SynthMini.cpp
+++ b/excluded/main_module/SynthMini.cpp
@@ -1,5 +1,5 @@
 #include "Arduino.h"
-#include "defines.h"
+#include "Defines.h"
 #include "SynthMini.h"
 
 SynthMini::SynthMini(Inputs* inputs)

--- a/src/EquationBankClassic.cpp
+++ b/src/EquationBankClassic.cpp
@@ -1,4 +1,4 @@
-#include "defines.h"
+#include "Defines.h"
 #include "EquationBankClassic.h"
 
 EquationBankClassic::EquationBankClassic()

--- a/src/ModuleSwitch.cpp
+++ b/src/ModuleSwitch.cpp
@@ -1,6 +1,6 @@
 #include "Arduino.h"
 #include "ModuleSwitch.h"
-#include "defines.h"
+#include "Defines.h"
 
 uint16_t ModuleSwitch::compute()
 {  


### PR DESCRIPTION
Incorrect filename case causes compilation to fail on filename case-sensitive operating systems like Linux.

Fixes https://github.com/esptiny86/espsynth86/issues/4